### PR TITLE
Update develop-custom-policies-reference.adoc

### DIFF
--- a/modules/ROOT/pages/develop-custom-policies-reference.adoc
+++ b/modules/ROOT/pages/develop-custom-policies-reference.adoc
@@ -95,8 +95,6 @@ category: Custom
 type: custom
 resourceLevelSupported: true
 standalone: true
-requiredCharacteristics: []
-providedCharacteristics:
  - Some Characteristic
 configuration: []
 ----


### PR DESCRIPTION
DOCS-3203 - Based on conversation with API Manager team, custom policies YAML tags "requiredCharacteristics" and "providedCharacteristics" are deprecated for Mule 4 and should not be used. After pressing API Manager "Add Policy" button, an error is thrown as well due to this.