### PR TITLE
Policy id is missing

### DIFF
--- a/modules/ROOT/pages/create-policy-definition-task.adoc
+++ b/modules/ROOT/pages/create-policy-definition-task.adoc
@@ -11,6 +11,7 @@ In this procedure, you create a YAML file that contains the policy definition fi
 +
 [source,yaml,linenums]
 ----
+policyId: <Custome policy id>
 id: query-param-filter
 name: Query Param Filter
 description: Filters query parameters


### PR DESCRIPTION
Policy ID is missing in the YAML template. If the customer doesnt add this setting in yaml , they will need to harcode it on policy xml, but in the documentation is calling a property

<policy xmlns="http://www.mulesoft.org/schema/mule/policy"
        id="{{policyId}}"
        policyName="Regex Filter"