### PR TITLE
suggest clarifying "Identifier" in RL policy

### DIFF
--- a/modules/ROOT/pages/rate-limiting-and-throttling.adoc
+++ b/modules/ROOT/pages/rate-limiting-and-throttling.adoc
@@ -29,6 +29,7 @@ When quota is exhausted, the resulting action depends on the policy:
 When the time window closes, quota is reset and a new window of the same fixed size starts.
 The policy creates one algorithm for each limit with its _quota_ per _time window_ configuration. Therefore, when multiple limits are configured, every algorithm must have available quota in its current window for the request to be accepted.
 
+(apologies for not making this a real PR - I don't know exactly how the "Identifier" aspect of RL policy works, so I can't suggest what enhancement is needed): 
 
 == Response Headers
 


### PR DESCRIPTION
@fermujica tagging you as requested

See https://mulesoft.slack.com/archives/C02HAAH50/p1549394617203100 for context.

  - the word "Identifier" doesn't appear anywhere in this doc-page. The utility of the "Identifier" and how to actually use it isn't identified at all; it's understood that the identifier identifies a bucket; what's missing is a sample usage to bridge the gap between the notion of a buckets subdividing the allocation, and what was envisioned as passing as the identifier qparam.

- also missing is what happens if (DoS scenario) someone makes 1 000 000 requests - within the RL bounds - with 1 000 000 different identifier values. Maybe it's appropriate to advise users "include identifier qparam in the RAML, and constrain it with an enum")
  - the fact that "Identifier" is optional probably also needs to be explained. Seems that with no "identifier" specified, all requests count against the same (ie default) "bucket".