### PR TITLE
Fix broken Mule 3 policies references and add Simple Security Manager policy documentation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -111,6 +111,7 @@
    **** xref:policy-mule3-json-threat.adoc[JSON Threat Protection]
    **** xref:policy-mule3-xml-threat.adoc[XML Threat Protection]
    **** xref:policy-mule3-ldap-security-manager.adoc[LDAP Security Manager]
+   **** xref:policy-mule3-simple-security-manager.adoc[Simple Security Manager]
    **** xref:policy-mule3-throttling-rate-limit.adoc[Throttling and Rate Limiting]
    **** xref:policy-mule3-rate-limiting-and-throttling-sla-based-policies.adoc[Rate Limiting and Throttling - SLA-Based]
    **** xref:policy-mule3-apply-rate-limiting.adoc[Rate Limiting Policy]

--- a/modules/ROOT/pages/policy-mule3-provided-policies.adoc
+++ b/modules/ROOT/pages/policy-mule3-provided-policies.adoc
@@ -63,7 +63,7 @@ Limits the number of messages per time period processed by an API at a maximum v
 * xref:policy-mule3-client-id-based-policies.adoc[Rate Limiting] +
 Limits the number of messages processed by an API per time period at a maximum value specified in the policy. The rate limiting is applied to all API calls, regardless of the source. Any messages beyond the maximum are rejected.
 
-* xref:[Simple Security Manager]:: Supports a placeholder security manager that can be configured with a hard-coded username and password for testing purposes.
+* xref:policy-mule3-simple-security-manager.adoc[Simple Security Manager]:: Supports a placeholder security manager that can be configured with a hard-coded username and password for testing purposes.
 
 * xref:policy-mule3-rate-limiting-and-throttling-sla-based-policies.adoc[Throttling -SLA-Based] +
 Throttles he number of messages per time period processed by an API at a maximum value specified in the SLA tier. Any messages beyond the maximum are queued for later processing. Enforcement is based on the client ID passed in the

--- a/modules/ROOT/pages/policy-mule3-provided-policies.adoc
+++ b/modules/ROOT/pages/policy-mule3-provided-policies.adoc
@@ -52,24 +52,26 @@ using this policy.
 * xref:policy-mule3-openam-oauth-token-enforcement-policy.adoc[OpenAM Access Token Enforcement] +
 Configures the API so that its endpoints require a mandatory and valid OpenAM token. This policy is only available to organizations using an OpenAM Federated Identity Management system.
 
-* * xref:policy-openid-connect.adoc[OpenID Connect OAuth 2.0 Token Enforcement] +
+* xref:policy-openid-connect.adoc[OpenID Connect OAuth 2.0 Token Enforcement] +
 Configures the API so that its endpoints require a mandatory and valid token. This policy is only available to organizations using an OpenID Connect Management system.
 
-// * xref:pingfederate-oauth-token-enforcement-policy.adoc[PingFederate Access Token Enforcement] :: Configures the API so that its endpoints require a mandatory and valid PingFederate token. This policy is only available to organizations using a PingFederate Federated Identity Management system.
+// * xref:pingfederate-oauth-token-enforcement-policy.adoc[PingFederate Access Token Enforcement] +
+// Configures the API so that its endpoints require a mandatory and valid PingFederate token. This policy is only available to organizations using a PingFederate Federated Identity Management system.
 
 * xref:policy-mule3-rate-limiting-and-throttling.adoc[Rate Limiting – SLA-Based] +
 Limits the number of messages per time period processed by an API at a maximum value specified in the SLA tier. Any messages beyond the maximum are rejected. Enforcement is based on the client ID passed in the request. See footnote.
 
-* xref:policy-mule3-client-id-based-policies.adoc[Rate Limiting] +
+* xref:policy-mule3-apply-rate-limiting.adoc[Rate Limiting] +
 Limits the number of messages processed by an API per time period at a maximum value specified in the policy. The rate limiting is applied to all API calls, regardless of the source. Any messages beyond the maximum are rejected.
 
-* xref:policy-mule3-simple-security-manager.adoc[Simple Security Manager]:: Supports a placeholder security manager that can be configured with a hard-coded username and password for testing purposes.
+* xref:policy-mule3-simple-security-manager.adoc[Simple Security Manager] +
+Supports a placeholder security manager that can be configured with a hard-coded username and password for testing purposes.
 
-* xref:policy-mule3-rate-limiting-and-throttling-sla-based-policies.adoc[Throttling -SLA-Based] +
+* xref:policy-mule3-rate-limiting-and-throttling-sla-based-policies.adoc[Throttling - SLA-Based] +
 Throttles he number of messages per time period processed by an API at a maximum value specified in the SLA tier. Any messages beyond the maximum are queued for later processing. Enforcement is based on the client ID passed in the
 request. See footnote.
 
-* xref:policy-mule3-client-id-based-policies.adoc[Throttling] +
+* xref:policy-mule3-throttling-rate-limit.adoc[Throttling] +
 Throttles the number of messages processed by an API per time period at a maximum value specified in the policy. The throttling is applied to all API calls, regardless of the source. Any messages beyond the maximum are queued for later
 processing.
 

--- a/modules/ROOT/pages/policy-mule3-provided-policies.adoc
+++ b/modules/ROOT/pages/policy-mule3-provided-policies.adoc
@@ -65,7 +65,7 @@ Limits the number of messages per time period processed by an API at a maximum v
 Limits the number of messages processed by an API per time period at a maximum value specified in the policy. The rate limiting is applied to all API calls, regardless of the source. Any messages beyond the maximum are rejected.
 
 * xref:policy-mule3-simple-security-manager.adoc[Simple Security Manager] +
-Supports a placeholder security manager that can be configured with a hard-coded username and password for testing purposes.
+Supports a placeholder security manager that can be configured with a hard-coded username and password for demonstration purposes.
 
 * xref:policy-mule3-rate-limiting-and-throttling-sla-based-policies.adoc[Throttling - SLA-Based] +
 Throttles he number of messages per time period processed by an API at a maximum value specified in the SLA tier. Any messages beyond the maximum are queued for later processing. Enforcement is based on the client ID passed in the

--- a/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
+++ b/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
@@ -20,7 +20,7 @@ When setting up this policy, you need to send requests to your APIs passing a ba
 
 [%header%autowidth.spread,cols="a,a"]
 |===
-| Element | Description |
+| Element | Description
 | *Username*
 | The hard-coded username that your simple security manager policy uses to authenticate your requests.
 

--- a/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
+++ b/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
@@ -11,7 +11,7 @@ This document assumes that you are an API Versions Owner for the API version tha
 
 == How Does This Policy Work?
 
-This policy acts as a simple security manager for you to test validations against your APIs using a username and password that you define when configuring your policy.
+This policy acts as a simple security manager to be used by policies which require one (such as Basic Authentication policy). It validates only one username and password combination. Usually used for testing/demonstrations purposes.
 
 When setting up this policy, you need to send requests to your APIs using a basic authentication mechanism specifying the username and password that you previously configured.
 

--- a/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
+++ b/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-The Simple Security Manager policy lets you configure a security manager placeholder with hard-coded username and password for testing purposes.
+The Simple Security Manager policy lets you configure a security manager with a username and password that you can define at the policy level.
 
 == Prerequisites
 
@@ -11,9 +11,9 @@ This document assumes that you are an API Versions Owner for the API version tha
 
 == How Does This Policy Work?
 
-This policy acts as a simple security manager for you to test validations against your APIs using a hard-coded username and password.
+This policy acts as a simple security manager for you to test validations against your APIs using a username and password that you define when configuring your policy.
 
-When setting up this policy, you need to send requests to your APIs passing a basic authentication with your configured username and passwords.
+When setting up this policy, you need to send requests to your APIs using a basic authentication mechanism specifying the username and password that you previously configured.
 
 
 == Policy Configuration
@@ -22,10 +22,10 @@ When setting up this policy, you need to send requests to your APIs passing a ba
 |===
 | Element | Description
 | *Username*
-| The hard-coded username that your simple security manager policy uses to authenticate your requests.
+| The username that your simple security manager policy uses to authenticate your requests.
 
 | *Password*
-| The hard-coded password that your simple security manager policy uses to authenticate your requests.
+| The password that your simple security manager policy uses to authenticate your requests.
 |===
 
 == See Also

--- a/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
+++ b/modules/ROOT/pages/policy-mule3-simple-security-manager.adoc
@@ -1,0 +1,33 @@
+= Simple Security Manager Policy
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+
+The Simple Security Manager policy lets you configure a security manager placeholder with hard-coded username and password for testing purposes.
+
+== Prerequisites
+
+This document assumes that you are an API Versions Owner for the API version that you want to manage, or that you are a member of the Organization Administrators role.
+
+== How Does This Policy Work?
+
+This policy acts as a simple security manager for you to test validations against your APIs using a hard-coded username and password.
+
+When setting up this policy, you need to send requests to your APIs passing a basic authentication with your configured username and passwords.
+
+
+== Policy Configuration
+
+[%header%autowidth.spread,cols="a,a"]
+|===
+| Element | Description |
+| *Username*
+| The hard-coded username that your simple security manager policy uses to authenticate your requests.
+
+| *Password*
+| The hard-coded password that your simple security manager policy uses to authenticate your requests.
+|===
+
+== See Also
+
+* xref:policy-mule3-ldap-security-manager.adoc[LDAP Security Manager]


### PR DESCRIPTION
• Adding a reference for the Simple Security Manager policy.
• Fixing broken references in the Mule 3 provided policies landing page.

