### PR TITLE
Add list of supported keystores.

### DIFF
--- a/modules/ROOT/pages/building-https-proxy.adoc
+++ b/modules/ROOT/pages/building-https-proxy.adoc
@@ -4,6 +4,8 @@ API Manager 2.x lets you use the secrets you stored in your secret group to buil
 By configuring a TLS context for your inbound and outbound traffic, you can ensure your traffic's security.
 
 The secrets manager integration is only supported by API Proxies running Mule 4, and only for CloudHub, Hybrid, and standalone deployments. +
+Supported keystores for the TLS context are JCEKS, PKCS12, and JKS.
+
 If you want to build and HTTPS Proxy in Mule 3 or Runtime Fabric deployment target, follow the xref:runtime-manager::building-an-https-service.adoc[Building an HTTPS Service] tutorial.
 
 == Prerequisites


### PR DESCRIPTION
Adding a list of supported keystores. 

TLS contexts using PEM types keystores cannot be selected when the secret groups' target is of type Mule.