### PR TITLE
API visibility restricted to env in crowd2

### DIFF
--- a/modules/ROOT/pages/environment-permission-task.adoc
+++ b/modules/ROOT/pages/environment-permission-task.adoc
@@ -5,8 +5,7 @@ endif::[]
 
 A permission called API Manager Environment Administrator gives users full access to API Manager operations inside environments. API Manager environment administrator only relates to actions inside of API Manager.
 
-To change permissions, you need access to the Access Management feature of Anypoint Platform. See <<To Grant Permissions>>
-for how to grant permissions.
+To change permissions, you need access to the Access Management feature of Anypoint Platform.
 
 API Manager also supports additional environment granular permissions:
 

--- a/modules/ROOT/pages/environment-permission-task.adoc
+++ b/modules/ROOT/pages/environment-permission-task.adoc
@@ -15,11 +15,21 @@ guarantee that deployment is successful due to its dependency on Runtime Manager
 * *Manage Alerts* - Create, edit, and delete alerts.
 * *Manage APIs Configuration* - Import APIs from Exchange. This permission also
 lets a user promote an API to another environment, edit the configuration of an API, and delete
-APIs. NOTE: this permission is per environment. API visibility can’t be restricted to specific users inside your Organization
+APIs.
++
+[NOTE]
+--
+This permission is per environment. API visibility can’t be restricted to specific users inside your Organization
+--
 * *Manage Contracts* - Deploy, reject, and revoke contracts. This permission also gives the user permission over tiers.
 * *Manage Policies* - Create, edit, delete, enable, and disable a policy. Also lets a user edit the order of policies.
 * *View Alerts* - List alerts and view configuration summary of an alert.
-* *View APIs Configuration* - List APIs, view configuration summary of an API, and download proxies. NOTE: this permission is per environment. API visibility can’t be restricted to specific users inside your Organization
+* *View APIs Configuration* - List APIs, view configuration summary of an API, and download proxies.
++
+[NOTE]
+--
+This permission is per environment. API visibility can’t be restricted to specific users inside your Organization
+--
 * *View Contracts* - List contracts and their configuration. Can also list SLA tiers and their configuration.
 * *View Policies* - View a listing of policies and view the configuration of a policy.
 

--- a/modules/ROOT/pages/environment-permission-task.adoc
+++ b/modules/ROOT/pages/environment-permission-task.adoc
@@ -16,11 +16,11 @@ guarantee that deployment is successful due to its dependency on Runtime Manager
 * *Manage Alerts* - Create, edit, and delete alerts.
 * *Manage APIs Configuration* - Import APIs from Exchange. This permission also
 lets a user promote an API to another environment, edit the configuration of an API, and delete
-APIs.
+APIs. NOTE: this permission is per environment. API visibility can’t be restricted to specific users inside your Organization
 * *Manage Contracts* - Deploy, reject, and revoke contracts. This permission also gives the user permission over tiers.
 * *Manage Policies* - Create, edit, delete, enable, and disable a policy. Also lets a user edit the order of policies.
 * *View Alerts* - List alerts and view configuration summary of an alert.
-* *View APIs Configuration* - List APIs, view configuration summary of an API, and download proxies.
+* *View APIs Configuration* - List APIs, view configuration summary of an API, and download proxies. NOTE: this permission is per environment. API visibility can’t be restricted to specific users inside your Organization
 * *View Contracts* - List contracts and their configuration. Can also list SLA tiers and their configuration.
 * *View Policies* - View a listing of policies and view the configuration of a policy.
 


### PR DESCRIPTION
Many cases were raised because customers want to restrict visibility to APIs per user, and not environment. But this was changed after new crowd release. We need a disclaimer so we reduce the ammount of cases being raised by our customers.