### PR TITLE
Escape the inline DW expression to avoid browser highlighting.

### DIFF
--- a/modules/ROOT/pages/policy-mule4-tokenization.adoc
+++ b/modules/ROOT/pages/policy-mule4-tokenization.adoc
@@ -125,7 +125,7 @@ For example:
 #[payload.people.creditCardNumber]
 --
 
-Only expressions using dots as field separators are allowed. While `#[payload.people.creditCardNumber]` is valid, `#[payload[‘people’]]` is not.
+Only expressions using dots as field separators are allowed. While `\#[payload.people.creditCardNumber]` is valid, `#[payload[‘people’]]` is not.
 
 | No. +
 Keep in mind that if you don't specify a selector expression, the policy will be applied, but won't tokenize anything from your payload.


### PR DESCRIPTION
Escaping the # character fixes the highlighting issue reported in the JIRA issue.

From:
<img width="411" alt="Screen Shot 2019-04-29 at 6 07 38 PM" src="https://user-images.githubusercontent.com/16763154/56929539-440cf900-6ab0-11e9-8ea3-55f897b25ed7.png">

To:
<img width="615" alt="Screen Shot 2019-04-29 at 6 54 20 PM" src="https://user-images.githubusercontent.com/16763154/56929548-4bcc9d80-6ab0-11e9-902b-9dddd01579a9.png">
