### PR TITLE
DOCS4874 Adding suffixes to titles about APID in API Manager

### DIFF
--- a/modules/ROOT/pages/api-manager-designer-archive.adoc
+++ b/modules/ROOT/pages/api-manager-designer-archive.adoc
@@ -1,4 +1,4 @@
-= API Designer
+= API Designer (in API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/api-manager-designer-archive.adoc
+++ b/modules/ROOT/pages/api-manager-designer-archive.adoc
@@ -1,4 +1,4 @@
-= API Designer (in API Manager)
+= API Designer (API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/consume-api-task.adoc
+++ b/modules/ROOT/pages/consume-api-task.adoc
@@ -1,4 +1,4 @@
-= To Consume a REST Service
+= To Consume a REST Service (in API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/consume-api-task.adoc
+++ b/modules/ROOT/pages/consume-api-task.adoc
@@ -1,4 +1,4 @@
-= To Consume a REST Service (in API Manager)
+= To Consume a REST Service (API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/design-raml-api-task.adoc
+++ b/modules/ROOT/pages/design-raml-api-task.adoc
@@ -1,4 +1,4 @@
-= To Design a Basic RAML API (in API Manager)
+= To Design a Basic RAML API (API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/design-raml-api-task.adoc
+++ b/modules/ROOT/pages/design-raml-api-task.adoc
@@ -1,4 +1,4 @@
-= To Design a Basic RAML API
+= To Design a Basic RAML API (in API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/designing-your-api.adoc
+++ b/modules/ROOT/pages/designing-your-api.adoc
@@ -1,4 +1,4 @@
-= API Designer Reference
+= API Designer Reference (for API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/designing-your-api.adoc
+++ b/modules/ROOT/pages/designing-your-api.adoc
@@ -1,4 +1,4 @@
-= API Designer Reference (for API Manager)
+= API Designer Reference (API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/simulate-api-task.adoc
+++ b/modules/ROOT/pages/simulate-api-task.adoc
@@ -1,4 +1,4 @@
-= To Simulate Calls to the API
+= To Simulate Calls to the API (in API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/simulate-api-task.adoc
+++ b/modules/ROOT/pages/simulate-api-task.adoc
@@ -1,4 +1,4 @@
-= To Simulate Calls to the API (in API Manager)
+= To Simulate Calls to the API (API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/tutorial-design-an-api.adoc
+++ b/modules/ROOT/pages/tutorial-design-an-api.adoc
@@ -1,4 +1,4 @@
-= About Designing a Basic RAML API (in API Manager)
+= About Designing a Basic RAML API (API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/tutorial-design-an-api.adoc
+++ b/modules/ROOT/pages/tutorial-design-an-api.adoc
@@ -1,4 +1,4 @@
-= About Designing a Basic RAML API
+= About Designing a Basic RAML API (in API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/tutorial-set-up-an-api.adoc
+++ b/modules/ROOT/pages/tutorial-set-up-an-api.adoc
@@ -1,4 +1,4 @@
-= To Set Up an API
+= To Set Up an API (in API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/tutorial-set-up-an-api.adoc
+++ b/modules/ROOT/pages/tutorial-set-up-an-api.adoc
@@ -1,4 +1,4 @@
-= To Set Up an API (in API Manager)
+= To Set Up an API (API Manager)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]


### PR DESCRIPTION
The point of adding suffixes to the titles is to distinguish these files from those for APID in Design Center.