### PR TITLE
(do not merge yet) remove AWS URLs from whitelist

### DIFF
--- a/modules/ROOT/pages/runtime-urls-whitelist.adoc
+++ b/modules/ROOT/pages/runtime-urls-whitelist.adoc
@@ -17,7 +17,6 @@ The following table shows you the ports or IPs/hostnames to add to your whitelis
 |*US*|*arm-auth-proxy.prod.cloudhub.io* |  443
 |*US*|*data-authenticator.anypoint.mulesoft.com* |  443
 |*US*|*exchange-files.anypoint.mulesoft.com* |  443
-|*US*|*exchange2-asset-manager-kprod.s3.amazonaws.com* |  443
 |*EU*|*eu1.anypoint.mulesoft.com* | 443
 |*EU*|*mule-manager.eu1.anypoint.mulesoft.com* | 443
 |*EU*|*runtime-manager.eu1.anypoint.mulesoft.com* | 443
@@ -25,7 +24,6 @@ The following table shows you the ports or IPs/hostnames to add to your whitelis
 |*EU*|*arm-auth-proxy.prod-eu.cloudhub.io* |  443
 |*EU*|*data-authenticator.eu1.anypoint.mulesoft.com* |  443
 |*EU*|*exchange-files.eu1.anypoint.mulesoft.com* |  443
-|*EU*|*exchange2-asset-manager-kprod-eu.s3.eu-central-1.amazonaws.com* |  443
 |===
 
 == See Also


### PR DESCRIPTION
Per https://www.mulesoft.org/jira/browse/EXC-2680 and https://mulesoft-roadmap.aha.io/epics/EX-E-170 , API policies now come from a MuleSoft domain URL and not an Amazon S3 domain URL. Before merging, confirm with Kuntal and possibly other Exchange team members that this is correct, and confirm with Fernando or API Manager team that the Amazon domains are not needed on the whitelist for any other purpose.