### PR TITLE
Update custom-policy-uploading-to-exchange.adoc

### DIFF
--- a/modules/ROOT/pages/custom-policy-uploading-to-exchange.adoc
+++ b/modules/ROOT/pages/custom-policy-uploading-to-exchange.adoc
@@ -25,7 +25,7 @@ You must configure your Exchange credentials:
         xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-       <id>Repository</id>
+       <id>exchange-server</id>
        <username>myusername</username>
        <password>mypassword</password>
      </server>


### PR DESCRIPTION
Corrected settings.xml <server> entry to use proper ID for the exchange-server. This was documented correctly later in this document but the example provided at the top did not match the server id in the pom.xml file generated by the archetype.