### PR TITLE
Added task information for accessing the client application credentials

### DIFF
--- a/modules/ROOT/pages/access-client-app-id-task.adoc
+++ b/modules/ROOT/pages/access-client-app-id-task.adoc
@@ -1,9 +1,9 @@
-= Getting Client ID and Client Secret of a registered Client App
+= Getting Client ID and Client Secret of a registered Client Application
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-You can view credentials, and reset Client Secret, of a client application after you approve it to access your API. When calling the API, the client application owner needs to pass these credentials if the API is protected with policies. These credentials are required based on the policy that is applied to your API. For example, the Client ID Enforcement policy requires both Client ID and Client Secret credentials. 
+As a client application owner of a registered client, you may be required to provide client application credentials when accessing an API. After a contract is created between the client application and the API, you can access the API using these credentials based on the policies that are applied. For example, if the API owner has applied the Client ID Enforcement policy on the API, you must provide the client ID, and optionally, the client secret information from your contract. 
 
 You must have the Organization Administrator privileges of the master organization, or must be the owner of the client application to access the credentials.  
 

--- a/modules/ROOT/pages/access-client-app-id-task.adoc
+++ b/modules/ROOT/pages/access-client-app-id-task.adoc
@@ -3,14 +3,15 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-You can view and reset the application credentials of a client application after you approve it to access your API. When calling the API, the client application owner needs to pass these credentials if the API is protected with policies.
+You can view credentials, and reset Client Secret, of a client application after you approve it to access your API. When calling the API, the client application owner needs to pass these credentials if the API is protected with policies. These credentials are required based on the policy that is applied to your API. For example, the Client ID Enforcement policy requires both Client ID and Client Secret credentials. 
 
-You must have the Organization Administrator privileges of the master organization to access the client application information.  
+You must have the Organization Administrator privileges of the master organization, or must be the owner of the client application to access the credentials.  
 
-To obtain the client ID and client secret credentials of a client application:
+To obtain the credentials of a client application:
 
 . From the left navigation pane in Anypoint Platform, click *Management Center* > *API Manager*.
 . On the left navigation, Click *Client Applications*.
 . From the details pane, click the application for which you want to view the client credentials.
 +
-The client ID and client secret credentials appear on the right for the selected application. 
+The Client ID and Client Secret credentials appear on the right for the selected application. 
+. Alternatively, if you need to obtain only the Client ID of the registered client application, select the correct version of the API and click *Contracts* from the left navigation. You can then click the specific API contract to view the details. 

--- a/modules/ROOT/pages/access-client-app-id-task.adoc
+++ b/modules/ROOT/pages/access-client-app-id-task.adoc
@@ -3,4 +3,14 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-As Organization Administrator of the master organization, after you approve a client app to access your API, you can access information about the app from API Manager > Contracts. You can view and reset the unique client ID and client secret for the application. When calling the API, the client app owner needs to pass these credentials if the API is protected with policies.
+You can view and reset the application credentials of a client application after you approve it to access your API. When calling the API, the client application owner needs to pass these credentials if the API is protected with policies.
+
+You must have the Organization Administrator privileges of the master organization to access the client application information.  
+
+To obtain the client ID and client secret credentials of a client application:
+
+. From the left navigation pane in Anypoint Platform, click *Management Center* > *API Manager*.
+. On the left navigation, Click *Client Applications*.
+. From the details pane, click the application for which you want to view the client credentials.
++
+The client ID and client secret credentials appear on the right for the selected application. 

--- a/modules/ROOT/pages/access-client-app-id-task.adoc
+++ b/modules/ROOT/pages/access-client-app-id-task.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-As a client application owner of a registered client, you may be required to provide client application credentials when accessing an API. After a contract is created between the client application and the API, you can access the API using these credentials based on the policies that are applied. For example, if the API owner has applied the Client ID Enforcement policy on the API, you must provide the client ID, and optionally, the client secret information from your contract. 
+As a client application owner of a registered client, you might be required to provide client application credentials when accessing an API. After a contract is created between the client application and the API, you can access the API using these credentials based on the policies that are applied. For example, if the API owner has applied the Client ID Enforcement policy on the API, you must provide the client ID, and optionally, the client secret information for the client application. 
 
 You must have the Organization Administrator privileges of the master organization, or must be the owner of the client application to access the credentials.  
 


### PR DESCRIPTION
There was no task information of how to access the client ID and client secret of a client application. Added that information now.