### PR TITLE
update broken link

### DIFF
--- a/modules/ROOT/pages/api-gateway-encryption-mule4.adoc
+++ b/modules/ROOT/pages/api-gateway-encryption-mule4.adoc
@@ -63,7 +63,7 @@ anypoint.platform.proxy_password.<n>
 If you add `wrapper.java.additional.n` entries to the configuration file, you must change each instance of `<n>` to a consecutive number, or Java does not parse the properties correctly.
 --
 +
-See xref:mule-runtime::passing-additional-arguments-to-the-jvm-to-control-mule.adoc[Passing Additional Arguments to the JVM to Control Mule] for more information.
+See xref:mule-runtime::mule-app-properties-system.adoc[Set System Properties in the wrapper.conf File] for more information.
 
 In the example above, your `client_id` would look as below:
 

--- a/modules/ROOT/pages/api-gateway-encryption-mule4.adoc
+++ b/modules/ROOT/pages/api-gateway-encryption-mule4.adoc
@@ -63,7 +63,7 @@ anypoint.platform.proxy_password.<n>
 If you add `wrapper.java.additional.n` entries to the configuration file, you must change each instance of `<n>` to a consecutive number, or Java does not parse the properties correctly.
 --
 +
-See xref:mule-runtime::mule-app-properties-system.adoc[Set System Properties in the wrapper.conf File] for more information.
+See xref:mule-runtime::mule-app-properties-system.adoc#set-properties[Set System Properties when Starting Mule] for more information.
 
 In the example above, your `client_id` would look as below:
 


### PR DESCRIPTION
It looks like @Cristian-Venticinque removed passing-additional-arguments-to-the-jvm-to-control-mule.adoc in https://github.com/mulesoft/docs-mule-runtime/pull/974 and there's a link to it from @priyaayyar 's docs at https://github.com/mulesoft/docs-api-manager/blob/v2.x/modules/ROOT/pages/api-gateway-encryption-mule4.adoc , which broke the build.