### PR TITLE
-n needed for the echo

### DIFF
--- a/modules/ROOT/pages/basic-authentication-simple-concept.adoc
+++ b/modules/ROOT/pages/basic-authentication-simple-concept.adoc
@@ -29,7 +29,7 @@ Authorization: Basic <username:password>
 
 where username:password is a base64-encoded string. In Mac OS X or Linux, for example:
 
-`echo '<Client Id>:<Client Secret>' | base64`
+`echo -n '<Client Id>:<Client Secret>' | base64`
 
 
 == See Also


### PR DESCRIPTION
A newline character is added by echo by default, `-n` strips that out. Without it, the newline gets encoded and the resulting string does not work.