### PR TITLE
Update viewing-api-analytics.adoc

### DIFF
--- a/modules/ROOT/pages/viewing-api-analytics.adoc
+++ b/modules/ROOT/pages/viewing-api-analytics.adoc
@@ -8,7 +8,7 @@ After logging into Anypoint Platform, navigate to API Manager, and on the Admini
 
 //API Analytics data is available for up to 90 days for chart related information and up to 30 days for the Report API. 
 
-You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of 30 days or less. However, Anypoint Monitoring provides more robust API usage data, with an extended retention period of 90 days. For more information about how you can view your data in Anypoint Monitoring, see xref:monitoring::api-analytics-dashboard.adoc[Anypoint Monitoring API Analytics Dashboard].
+You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of upto 30 days. However, Anypoint Monitoring provides more robust API usage data, with an extended retention period of 90 days. For more information about how you can view your data in Anypoint Monitoring, see xref:monitoring::api-analytics-dashboard.adoc[Anypoint Monitoring API Analytics Dashboard].
 
 When you access the analytics for your APIs, by default you land on your Overview Dashboard that displays these charts:
 

--- a/modules/ROOT/pages/viewing-api-analytics.adoc
+++ b/modules/ROOT/pages/viewing-api-analytics.adoc
@@ -8,7 +8,7 @@ After logging into Anypoint Platform, navigate to API Manager, and on the Admini
 
 //API Analytics data is available for up to 90 days for chart related information and up to 30 days for the Report API. 
 
-You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of 30 days or more. However, Anypoint Monitoring provides more robust API usage data, with an extended retention period of 90 days. For more information about how you can view your data in Anypoint Monitoring, see xref:monitoring::api-analytics-dashboard.adoc[Anypoint Monitoring API Analytics Dashboard].
+You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of 30 days or less. However, Anypoint Monitoring provides more robust API usage data, with an extended retention period of 90 days. For more information about how you can view your data in Anypoint Monitoring, see xref:monitoring::api-analytics-dashboard.adoc[Anypoint Monitoring API Analytics Dashboard].
 
 When you access the analytics for your APIs, by default you land on your Overview Dashboard that displays these charts:
 

--- a/modules/ROOT/pages/viewing-api-analytics.adoc
+++ b/modules/ROOT/pages/viewing-api-analytics.adoc
@@ -8,7 +8,7 @@ After logging into Anypoint Platform, navigate to API Manager, and on the Admini
 
 //API Analytics data is available for up to 90 days for chart related information and up to 30 days for the Report API. 
 
-You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of upto 30 days. However, Anypoint Monitoring provides more robust API usage data, with an extended retention period of 90 days. For more information about how you can view your data in Anypoint Monitoring, see xref:monitoring::api-analytics-dashboard.adoc[Anypoint Monitoring API Analytics Dashboard].
+You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of up to 30 days. However, Anypoint Monitoring provides more robust API usage data, with an extended retention period of 90 days. For more information about how you can view your data in Anypoint Monitoring, see xref:monitoring::api-analytics-dashboard.adoc[Anypoint Monitoring API Analytics Dashboard].
 
 When you access the analytics for your APIs, by default you land on your Overview Dashboard that displays these charts:
 


### PR DESCRIPTION
Updated from "You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of 30 days or more."
to 
"You can view your API Analytics data from both API Manager and Anypoint Monitoring. API Manager has a retention period of 30 days or less."
