### PR TITLE
AP-4863: Client ID enf. secure Mule 3 configuration

### DIFF
--- a/modules/ROOT/pages/client-id-based-policies.adoc
+++ b/modules/ROOT/pages/client-id-based-policies.adoc
@@ -72,21 +72,22 @@ Example request using curl:
 curl "http://localhost/myResource?client_id=1234&client_secret=abcd"
 ----
 
-Example DataWeave 2.0 expression to be used when configuring the policy:
+Example DataWeave 2.0 expression to be used when configuring the policy for Mule 4:
 [source,text]
 ----
 #[attributes.queryParams.'client_id']
 #[attributes.queryParams.'client_secret']
 ----
 
-In this example, the requester must send the two specified query parameters with the request. Although this is a supported configuration, it poses possible security risks. The recommended method is to use headers.
+In this Mule 4 example, the requester must send the two specified query parameters with the request. Although this is a supported configuration, it poses possible security risks. The recommended method is to use headers irrespective of the Mule version you are using.
 
-The previous example is the default configuration for Mule 3 policies that enforce Client IDs. For a more secure configuration using headers, use these MEL expressions:
+Example MEL expression to be used when configuring the policy with headers for Mule 3:
+[source,text]
+
 ----
 #[message.inboundProperties['client_id']]
 #[message.inboundProperties['client_secret']]
 ----
-====
 
 === Obtaining Credentials Using HTTP Request Payload
 

--- a/modules/ROOT/pages/client-id-based-policies.adoc
+++ b/modules/ROOT/pages/client-id-based-policies.adoc
@@ -81,9 +81,7 @@ Example DataWeave 2.0 expression to be used when configuring the policy:
 
 In this example, the requester must send the two specified query parameters with the request. Although this is a supported configuration, it poses possible security risks. The recommended method is to use headers.
 
-[WARNING]
-====
-This is the default configuration for Mule 3 policies that enforce Client IDs. In order to change to a more secure configuration using headers, use these MEL expressions:
+The previous example is the default configuration for Mule 3 policies that enforce Client IDs. For a more secure configuration using headers, use these MEL expressions:
 ----
 #[message.inboundProperties['client_id']]
 #[message.inboundProperties['client_secret']]

--- a/modules/ROOT/pages/client-id-based-policies.adoc
+++ b/modules/ROOT/pages/client-id-based-policies.adoc
@@ -81,6 +81,15 @@ Example DataWeave 2.0 expression to be used when configuring the policy:
 
 In this example, the requester must send the two specified query parameters with the request. Although this is a supported configuration, it poses possible security risks. The recommended method is to use headers.
 
+[WARNING]
+====
+This is the default configuration for Mule 3 policies that enforce Client IDs. In order to change to a more secure configuration using headers, use these MEL expressions:
+----
+#[message.inboundProperties['client_id']]
+#[message.inboundProperties['client_secret']]
+----
+====
+
 === Obtaining Credentials Using HTTP Request Payload
 
 Example request using curl:


### PR DESCRIPTION
As https://www.mulesoft.org/jira/browse/AP-4863 describes, our policies include some insecure default configuration, but in order to not break backwards compatibility we have agreed with the Product Security team to mitigate this vulnerability by explicitly documenting it and the way to configure it in a secure way. 
This PR's intention is to highlight the fact that Mule 3's default configuration deserves attention, and to propose the correct MEL expression for configuring headers (since the rest of this document shows solely DW 2.0, which is not what is used in Mule 3)