### PR TITLE
OutputType is not a valid attribute

### DIFF
--- a/modules/ROOT/pages/http-policy-transform.adoc
+++ b/modules/ROOT/pages/http-policy-transform.adoc
@@ -81,7 +81,7 @@ A DataWeave expression that resolves to the Map of the headers to be added to pr
 +
 [source,xml,linenums]
 ----
-<http-transform:add-request-headers outputType="response">
+<http-transform:add-request-headers>
 <http-transform:headers>#[
 {
   'FirstHeader': 'FirstHeaderValue',


### PR DESCRIPTION
outputType="response" will cause deployment error as it is not a valid attribute