### PR TITLE
fix the broken nested item

### DIFF
--- a/modules/ROOT/pages/api-proxy-landing-page.adoc
+++ b/modules/ROOT/pages/api-proxy-landing-page.adoc
@@ -55,6 +55,7 @@ The proxy enables you to protect your API with the full capabilities of the API 
 * Implements validations
 +
 Most proxies, including RAML, REST, and WSDL proxies, enable you to perform validations on all incoming requests, using your API definition. You can choose different levels of validation, depending on your requirements:
++
 ** Regular validations
 + 
 Compare the payload, query parameters, URI parameters, headers, and form parameters with the schema defined in your API specification. When using this configuration, the unspecified query parameters and headers in the API specification are also sent to the backend service. 


### PR DESCRIPTION
It is actually shown like this in [docs](https://docs.mulesoft.com/api-manager/2.x/api-proxy-landing-page):

![image](https://user-images.githubusercontent.com/39317466/119263862-2b9c3980-bbb7-11eb-8b97-6d94f662fb2d.png)

Fixed this here.
