### PR TITLE
Typo in 1st line - Nothing to compare with

### DIFF
--- a/modules/ROOT/pages/policies-compare-mule3-and-mule4.adoc
+++ b/modules/ROOT/pages/policies-compare-mule3-and-mule4.adoc
@@ -4,7 +4,7 @@ include::_attributes.adoc[]
 endif::[]
 :keywords: policy, custom, ootb, offline
 
-Policies in Mule versions 3 and differ based on how they are implemented and the level of support provided.
+Policies in Mule versions 3 and 4 differ based on how they are implemented and the level of support provided.
 
 [%header,cols="40a,50a,50a"]
 |===


### PR DESCRIPTION
"Policies in Mule versions 3 and differ based on how they are implemented and the level of support provided"
Here Mule version 3 is compared with Mule version 4, but 4 is missing in the statement