### PR TITLE
added a note on "protected" properties

### DIFF
--- a/modules/ROOT/pages/policy-mule3-creating-custom-policy.adoc
+++ b/modules/ROOT/pages/policy-mule3-creating-custom-policy.adoc
@@ -65,6 +65,8 @@ requiredCharacteristics: []
 +
 . Add a configuration element and two propertyName fields having the values regexFilter and queryParam.
 . Add properties to define the regular expression to filter the parameter and to name and define the query parameter that must be evaluated.
+[NOTE]
+The following property names can be used, however, they won't be properly displayed in API Manager when viewing or editing the custom policy: "apiName", "apiVersionId","apiVersionName"
 +
 [source,yaml,linenums]
 ----


### PR DESCRIPTION
I have had a case where the customer was using one of these properties and when displaying the policy in API Manager, the previously set value does not persist on the UI. However, the value is used for the policy itself, but it is still best if customers don't use this one.