### PR TITLE
W-11098233: Links to the platform should not have 'www.'

### DIFF
--- a/modules/ROOT/pages/add-remove-headers.adoc
+++ b/modules/ROOT/pages/add-remove-headers.adoc
@@ -20,19 +20,19 @@ To download the header policies:
 +
 * Add Request Headers Policy
 +
-`+https://www.anypoint.mulesoft.com/exchange/?search=Add%20Request%20Headers%20Policy+`
+`+https://anypoint.mulesoft.com/exchange/?search=Add%20Request%20Headers%20Policy+`
 +
 * Remove Request Headers Policy
 +
-`+https://www.anypoint.mulesoft.com/exchange/?search=Remove%20Request%20Headers%20Policy+`
+`+https://anypoint.mulesoft.com/exchange/?search=Remove%20Request%20Headers%20Policy+`
 +
 * Add Response Headers Policy
 +
-`+https://www.anypoint.mulesoft.com/exchange/?search=Add%20Response%20Headers%20Policy+`
+`+https://anypoint.mulesoft.com/exchange/?search=Add%20Response%20Headers%20Policy+`
 +
 * Remove Response Headers Policy
 +
-`+https://www.anypoint.mulesoft.com/exchange/?search=Remove%20Response%20Headers%20Policy+`
+`+https://anypoint.mulesoft.com/exchange/?search=Remove%20Response%20Headers%20Policy+`
 +
 . Unzip each policy archive.
 


### PR DESCRIPTION
[W-11098233](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000wLRxMYAW/view): 
Based on the engineering feedback, we should update the links to the Anypoint platform to remove the `www.` section of the URL as it might not be fully supported.