### PR TITLE
W-15537743 Remove "Scope and Limitations" item with broken link

### DIFF
--- a/modules/ROOT/pages/migrate-client-apps.adoc
+++ b/modules/ROOT/pages/migrate-client-apps.adoc
@@ -25,7 +25,6 @@ Before migrating the client application, ensure that you:
 
 Before you migrate your client applications to Anypoint Platform, review the following scope and limitations: 
 
-* If the organization of the API that your application consumes has registered an external client provider (for example, PingFederate or Okta), review the section: <<external_client,Organizations with Registered External Client Providers>>.
 * Do not attempt to update the client ID and client secret of your application.
 +
 This feature is not supported.


### PR DESCRIPTION
Removed broken link to non-existent Scope and Limitations link to section "Organizations with Registered External Client Providers" because it has been broken for (I think) four years and no one has complained yet, so IMO no one is trying to read that link.