### PR TITLE
W-16405693 Delete outdated "Writer's Quality Checklist" PR template (pull_request_template.md)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,0 @@
-### Description
-
-** Briefly explain the changes introduced in this PR **


### PR DESCRIPTION
This checklist is:
Out of date, doese not reflect our current process.
Invisible because no one reads it anymore, so it doesn't make sense to replace it with an updated checklist (open to updating later, if I get feedback that we DO want that).