### PR TITLE
W-18531782 Update upstream limits for APIM 2.5.12

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,9 @@
 name: api-manager
 title: API Manager
 version: 2.x
+asciidoc:
+  attributes:
+    upstreams-per-api-var: 100
+    routes-per-api-var: 100
 nav:
 - modules/ROOT/nav.adoc

--- a/antora.yml
+++ b/antora.yml
@@ -3,7 +3,7 @@ title: API Manager
 version: 2.x
 asciidoc:
   attributes:
-    upstreams-per-api-var: 100
-    routes-per-api-var: 100
+    upstreams-per-api: 100
+    routes-per-api: 100
 nav:
 - modules/ROOT/nav.adoc

--- a/modules/ROOT/pages/create-instance-task-flex.adoc
+++ b/modules/ROOT/pages/create-instance-task-flex.adoc
@@ -67,15 +67,15 @@ image:multiple-upstreams.png[Flex Gateway manages the traffic to multiple upstre
 [%header%autowidth.spread,cols="a,>.<a,a"]
 |===
 | Limit | Value | Notes
-| Upstreams per API | 50 | Each API supports 50 upstreams. The 50 upstreams can consist of a combination of different routes.
-| Routes per API | 50 | Each API supports 50 routes. 
+| Upstreams per API | 100 | Each API supports 100 upstreams. The 100 upstreams can consist of a combination of different routes.
+| Routes per API | 100 | Each API supports 100 routes. 
 | Upstreams per route| 10|
 | Headers per route rule | 10| 
 |===
 
 === Routes
 
-Each API instance supports up to 50 routes and each route can support up to 10 upstream services. Configure what requests a route can receive by defining route rules and a route order. At least one route per API instance is required. 
+Each API instance supports up to 100 routes and each route can support up to 10 upstream services. Configure what requests a route can receive by defining route rules and a route order. At least one route per API instance is required. 
 
 Before adding additional routes, enter an optional *Route label* for clarity.
 
@@ -159,7 +159,7 @@ For example, in a configuration in which route one has the `GET` method defined 
 
 You can use multiple upstream services in a single route to direct requests to similar services. For example, to test the performance of a new beta upstream service without sending all traffic to the new service, you can direct half of the traffic to a stable upstream service and half to the new upstream service.
 
-Each API instance route can support up to 50 upstream services, but at least one upstream service is required for each route. 
+Each API instance route can support up to 100 upstream services, but at least one upstream service is required for each route. 
 
 What upstream service within the route each request is sent to is random and independent of any previous request. The upstream *Weight* defines the percentage chance of a request being sent to a particular upstream service.
 

--- a/modules/ROOT/pages/create-instance-task-flex.adoc
+++ b/modules/ROOT/pages/create-instance-task-flex.adoc
@@ -67,15 +67,15 @@ image:multiple-upstreams.png[Flex Gateway manages the traffic to multiple upstre
 [%header%autowidth.spread,cols="a,>.<a,a"]
 |===
 | Limit | Value | Notes
-| Upstreams per API | 100 | Each API supports 100 upstreams. The 100 upstreams can consist of a combination of different routes.
-| Routes per API | 100 | Each API supports 100 routes. 
+| Upstreams per API | {upstreams-per-api} | Each API supports {upstreams-per-api} upstreams. The {upstreams-per-api} upstreams can consist of a combination of different routes.
+| Routes per API | {routes-per-api} | Each API supports {routes-per-api} routes. 
 | Upstreams per route| 10|
 | Headers per route rule | 10| 
 |===
 
 === Routes
 
-Each API instance supports up to 100 routes and each route can support up to 10 upstream services. Configure what requests a route can receive by defining route rules and a route order. At least one route per API instance is required. 
+Each API instance supports up to {routes-per-api} routes and each route can support up to 10 upstream services. Configure what requests a route can receive by defining route rules and a route order. At least one route per API instance is required. 
 
 Before adding additional routes, enter an optional *Route label* for clarity.
 
@@ -159,7 +159,7 @@ For example, in a configuration in which route one has the `GET` method defined 
 
 You can use multiple upstream services in a single route to direct requests to similar services. For example, to test the performance of a new beta upstream service without sending all traffic to the new service, you can direct half of the traffic to a stable upstream service and half to the new upstream service.
 
-Each API instance route can support up to 100 upstream services, but at least one upstream service is required for each route. 
+Each API instance route can support up to {upstreams-per-api} upstream services, but at least one upstream service is required for each route. 
 
 What upstream service within the route each request is sent to is random and independent of any previous request. The upstream *Weight* defines the percentage chance of a request being sent to a particular upstream service.
 

--- a/modules/ROOT/pages/limits.adoc
+++ b/modules/ROOT/pages/limits.adoc
@@ -30,10 +30,10 @@ API Manager limits the number of upstream services you can expose through a sing
 |===
 | Limit | Value | Notes
 | Upstreams per API
-| 100
+| {upstreams-per-api}
 | 
 | Routes per API
-| 100
+| {routes-per-api}
 | 
 | Upstreams per route
 | 10

--- a/modules/ROOT/pages/limits.adoc
+++ b/modules/ROOT/pages/limits.adoc
@@ -30,10 +30,10 @@ API Manager limits the number of upstream services you can expose through a sing
 |===
 | Limit | Value | Notes
 | Upstreams per API
-| 50
+| 100
 | 
 | Routes per API
-| 50
+| 100
 | 
 | Upstreams per route
 | 10


### PR DESCRIPTION
Today's API Manager 2.5.12 release updates a couple per API limits.
It turns out that we talk about them a few places, so I created two variables for now.

- Upstreams per API = 100 (was 50)
- Routes per API = 100 (was 50)

I ran a local build and checked the output & errors.
