### PR TITLE
[W-19340605] Add team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
+#GUSINFO:MS CX Engineering,MS CX (DOCS)
 * @failup @mulesoft/team-docs


### PR DESCRIPTION
This addresses an issue in the Signals Intelligence Platform (SIP) alerts dashboard where this repo displays with team "No CODEOWNERS Found, Not Found: 404". 