### PR TITLE
W-19584366 Build-Log-errors2

### DIFF
--- a/modules/ROOT/pages/_partials/key-metrics.adoc
+++ b/modules/ROOT/pages/_partials/key-metrics.adoc
@@ -1,6 +1,3 @@
-[[key-metrics]]
-== Understanding Key Metrics
-
 The *Key Metrics* section of the API summary contains the following charts:
 
 Total Requests::

--- a/modules/ROOT/pages/latest-overview-concept.adoc
+++ b/modules/ROOT/pages/latest-overview-concept.adoc
@@ -123,7 +123,7 @@ image::api-instance-summary.png[API Summary page]
 
 The API Summary page includes a Key Metrics section. 
 
-include::partial$key-metrics.adoc[leveloffset=+2]
+include::partial$key-metrics.adoc[]
 
 === API Alerts
 


### PR DESCRIPTION
(tag (and heading) unnecessary in https://docs.mulesoft.com/api-manager/latest/latest-overview-concept#key-metrics). This partial isn't included anywhere else in our doc set.