### PR TITLE
@W-23713942-Document API Manager platform request limits

### DIFF
--- a/modules/ROOT/pages/limits.adoc
+++ b/modules/ROOT/pages/limits.adoc
@@ -32,6 +32,25 @@ API Manager limits various entity properties and configurations to ensure optima
 | 
 |===
 
+[[api-manager-platform-request-limits]]
+== API Manager Platform Request Limits
+
+Anypoint Platform enforces rate limits on requests to certain API Manager control plane endpoints to protect service stability and ensure fair use. These limits apply to calls made to the API Manager backend APIs, not to the API instances that you manage.
+
+When a request exceeds the rate limit for an endpoint, the platform returns a `429` status code.
+
+[%header%autowidth.spread,cols="a,a,a"]
+|===
+|Endpoint |Rate Limit Per Client IP Address | Status Code
+|`/login` |30 requests per second | `429`
+|`/api/v1/organizations/{organizationId}/environments/{environmentId}/apis/{apiId}/contracts/{contractId}` |600 requests per minute | `429`
+|`/repository/applications/{applicationId}` .3+|120 requests per minute .3+| `429`
+|`/repository/v2/organizations/{organizationId}/applications/{applicationId}`
+|`/consumers/api/v1/organizations/{organizationId}/applications/{applicationId}`
+|`/xapi/v1/organizations/{organizationId}/exchange-policy-templates/{groupId}/{assetId}/{version}/implementations` .2+|120 requests per minute .2+| `429`
+|`/consumers/api/v1/organizations/{organizationId}/groups/{groupId}/assets/{assetId}/versions/{version}/implementations`
+|===
+
 == API Group Limits
 
 API Manager limits the number of features allowed for each business group.

--- a/modules/ROOT/pages/limits.adoc
+++ b/modules/ROOT/pages/limits.adoc
@@ -33,15 +33,15 @@ API Manager limits various entity properties and configurations to ensure optima
 |===
 
 [[api-manager-platform-request-limits]]
-== API Manager Platform Request Limits
+== Control Plane API Rate Limits
 
-Anypoint Platform enforces rate limits on requests to certain API Manager control plane endpoints to protect service stability and ensure fair use. These limits apply to calls made to the API Manager backend APIs, not to the API instances that you manage.
+Anypoint Platform applies rate limits per client IP address to requests sent to the following API Manager control plane endpoints. These limits don't apply to requests sent to your managed API instances.
 
-When a request exceeds the rate limit for an endpoint, the platform returns a `429` status code.
+When requests from a client IP address exceed an endpoint's rate limit, Anypoint Platform returns a 429 (Too Many Requests) status code.
 
-[%header%autowidth.spread,cols="a,a,a"]
+[%header%autowidth.spread,cols="a,>.<a,a"]
 |===
-|Endpoint |Rate Limit Per Client IP Address | Status Code
+|Endpoint |Rate Limit | Status Code
 |`/login` |30 requests per second | `429`
 |`/api/v1/organizations/{organizationId}/environments/{environmentId}/apis/{apiId}/contracts/{contractId}` |600 requests per minute | `429`
 |`/repository/applications/{applicationId}` .3+|120 requests per minute .3+| `429`


### PR DESCRIPTION
## What
  Adds an "API Manager Platform Request Limits" section to limits.adoc documenting the per-client-IP rate limits enforced on API Manager
  control-plane endpoints by Global Rate Limiting (GRLS).

  ## Limits documented
  | Endpoint | Limit (per client IP) | Status |
  |---|---|---|
  | /login | 30 req/sec | 429 |
  | contract detail | 600 req/min | 429 |
  | application detail | 120 req/min | 429 |
  | policy-template implementations | 120 req/min | 429 |

  ## Style
  Mirrors the CloudHub Management API rate-limits table (per-client-IP column, backtick status codes). Region/Control-Plane column
  omitted — API Manager limits are uniform across the prod mesh. Paths shown without the /apimanager gateway prefix.

  ## Pre-PR Review
  Reviewed with the code-review agent (1 iteration, zero CRITICAL). Verified the AsciiDoc rowspan grid reconciles (18 cells / 24 positions − 6 spanned); table renders cleanly at 3 columns. Table attribute style aligned with the file's existing tables.


  GUS: W-23713942